### PR TITLE
Fix typos across multiple files

### DIFF
--- a/Examples/BlazorWebAssemblySupabaseTemplate/Pages/Auth/Login.razor.cs
+++ b/Examples/BlazorWebAssemblySupabaseTemplate/Pages/Auth/Login.razor.cs
@@ -8,7 +8,7 @@ public partial class Login
     public async Task OnClickLogin()
     {
         await AuthService.Login(Email, Password);
-        Snackbar.Add("Login successfull");
+        Snackbar.Add("Login successful");
         NavigationManager.NavigateTo($"/");
     }
 }

--- a/Examples/BlazorWebAssemblySupabaseTemplate/Pages/CrudPrivate/CrudPagePrivate.razor
+++ b/Examples/BlazorWebAssemblySupabaseTemplate/Pages/CrudPrivate/CrudPagePrivate.razor
@@ -11,7 +11,7 @@
 
     <MudText Typo="Typo.h5">Todos private by RLS</MudText>
     <br>
-    <MudText Typo="Typo.body2">The data in this page is filtered automaticaly by Row Level Security policies.</MudText>
+    <MudText Typo="Typo.body2">The data in this page is filtered automatically by Row Level Security policies.</MudText>
     <MudText Typo="Typo.body2">This way, you need to be logged in to see the content of this table and to insert an item.</MudText>
     <MudText Typo="Typo.body2">Also, each user logged in can only SELECT (get from database) and UPDATE its own rows.</MudText>
     <MudText Typo="Typo.body2">See the code file <i>DatabasePolicies.sql</i> on GitHub to get to know the policies.</MudText>

--- a/Examples/BlazorWebAssemblySupabaseTemplate/Pages/Index.razor
+++ b/Examples/BlazorWebAssemblySupabaseTemplate/Pages/Index.razor
@@ -29,7 +29,7 @@
         <AuthorizeView>
             <Authorized>
                 <MudText Typo="Typo.h6">Auth test area.</MudText>
-                <MudText Typo="Typo.body1">Congratulatons! You are logged in!</MudText>
+                <MudText Typo="Typo.body1">Congratulations! You are logged in!</MudText>
             </Authorized>
             <NotAuthorized>
                 <MudText Typo="Typo.h6">Auth test area.</MudText>

--- a/Examples/BlazorWebAssemblySupabaseTemplate/README.MD
+++ b/Examples/BlazorWebAssemblySupabaseTemplate/README.MD
@@ -7,7 +7,7 @@
             - Insert some row
             - you will see the row displayed below
             - press F5 on the browser
-            - the rows will disapear
+            - the rows will disappear
         - Maybe i created CustomSupabaseSessionHandler wrong. But it seem like that the token is not being sent with the headers...
 
     - create policy to insert that check if the user_id is the same of the user logged in trying to insert.

--- a/Examples/BlazorWebAssemblySupabaseTemplate/Services/DatabaseService.cs
+++ b/Examples/BlazorWebAssemblySupabaseTemplate/Services/DatabaseService.cs
@@ -63,7 +63,7 @@ public class DatabaseService
 			if(ex.Response?.StatusCode == HttpStatusCode.Forbidden)
 				await _dialogService.ShowMessageBox(
 					"Warning",
-					"This database resquest was forbidden."
+					"This database request was forbidden."
 				);
 			else		
 				await _dialogService.ShowMessageBox(

--- a/Examples/BlazorWebAssemblySupabaseTemplate/Shared/MainLayout.razor.cs
+++ b/Examples/BlazorWebAssemblySupabaseTemplate/Shared/MainLayout.razor.cs
@@ -12,7 +12,7 @@ public partial class MainLayout
     private async Task OnClickLogout()
     {
         await AuthService.Logout();
-        Snackbar.Add("Logout successfull");
+        Snackbar.Add("Logout successful");
         NavigationManager.NavigateTo($"/");
     }
 }


### PR DESCRIPTION
A handful of typographical errors were corrected in various files, primarily concerning user-facing text. These changes were made to enhance the readability and professionalism of the project. Changes include correcting "Congratulatons" to "Congratulations", "successfull" to "successful", "disapear" to "disappear", "automaticaly" to "automatically", and "resquest" to "request".
