### PR TITLE
chore: Add custom headers from options in Client.cs

### DIFF
--- a/Supabase/Client.cs
+++ b/Supabase/Client.cs
@@ -249,6 +249,9 @@ namespace Supabase
         public Task<TModeledResponse?> Rpc<TModeledResponse>(string procedureName, object? parameters) =>
             _postgrest.Rpc<TModeledResponse>(procedureName, parameters);
 
+        /// <summary>
+        /// Produces dictionary of Headers that will be supplied to child clients.
+        ///</summary>
         internal Dictionary<string, string> GetAuthHeaders()
         {
             var headers = new Dictionary<string, string>
@@ -257,9 +260,7 @@ namespace Supabase
             };
 
             if (_supabaseKey != null)
-            {
                 headers["apiKey"] = _supabaseKey;
-            }
 
             // In Regard To: https://github.com/supabase/supabase-csharp/issues/5
             if (_options.Headers.TryGetValue("Authorization", out var header))
@@ -272,12 +273,9 @@ namespace Supabase
                 headers["Authorization"] = $"Bearer {bearer}";
             }
 
-            // Add custom headers from options
-            // This will overwrite any existing headers with the same key, not sure if that's the desired behavior
+            // Add supplied headers from `ClientOptions` by developer
             foreach (var kvp in _options.Headers)
-            {
                 headers[kvp.Key] = kvp.Value;
-            }
 
             return headers;
         }

--- a/Supabase/Client.cs
+++ b/Supabase/Client.cs
@@ -274,9 +274,9 @@ namespace Supabase
 
             // Add custom headers from options
             // This will overwrite any existing headers with the same key, not sure if that's the desired behavior
-            foreach (var (key, value) in _options.Headers)
+            foreach (var kvp in _options.Headers)
             {
-                headers[key] = value;
+                headers[kvp.Key] = kvp.Value;
             }
 
             return headers;

--- a/Supabase/Client.cs
+++ b/Supabase/Client.cs
@@ -244,7 +244,7 @@ namespace Supabase
         /// <inheritdoc />
         public Task<BaseResponse> Rpc(string procedureName, object? parameters) =>
             _postgrest.Rpc(procedureName, parameters);
-        
+
         /// <inheritdoc />
         public Task<TModeledResponse?> Rpc<TModeledResponse>(string procedureName, object? parameters) =>
             _postgrest.Rpc<TModeledResponse>(procedureName, parameters);
@@ -270,6 +270,13 @@ namespace Supabase
             {
                 var bearer = Auth.CurrentSession?.AccessToken ?? _supabaseKey;
                 headers["Authorization"] = $"Bearer {bearer}";
+            }
+
+            // Add custom headers from options
+            // This will overwrite any existing headers with the same key, not sure if that's the desired behavior
+            foreach (var (key, value) in _options.Headers)
+            {
+                headers[key] = value;
             }
 
             return headers;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature:
Adds the possibility own headers via the options.Headers

## What is the current behavior?

https://github.com/supabase-community/supabase-csharp/issues/167

## What is the new behavior?

It takes the custom headers from options.Headers, but this will overwrite any existing headers with the same key, not sure if that's the desired behavior
