### PR TITLE
feat: Allow Newtonsoft.Json >= 13.0.2 (from =13.0.3)

### DIFF
--- a/Supabase/Supabase.csproj
+++ b/Supabase/Supabase.csproj
@@ -49,7 +49,7 @@
         <PackageReference Include="Supabase.Postgrest" Version="4.1.0" />
         <PackageReference Include="Supabase.Realtime" Version="7.2.0" />
         <PackageReference Include="Supabase.Storage" Version="2.0.2" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="[13.0.2,)" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
## What kind of change does this PR introduce?

feat!: Allow Newtonsoft.Json >= 13.0.2 (from =13.0.3)

## What is the current behavior?

Disallows client-server parity due to the current Unity LTS limitations

Unity 6 LTS uses max 13.0.2, currently

## What is the new behavior?

Allows Unity 6 LTS backwards compatibility, useful for client-server parity

## Additional context

Just a minor version diff. Since it allows .2+, it's not breaking
