### PR TITLE
 chore: grant read/write on channels to API roles in REST migration

### DIFF
--- a/supabase/migrations/1751173604_rest_schema.sql
+++ b/supabase/migrations/1751173604_rest_schema.sql
@@ -10,3 +10,4 @@ create table public.channels (
 
 alter table public.channels replica identity full;
 alter publication supabase_realtime add table public.channels;
+grant select, insert, update, delete on public.channels to anon, authenticated, service_role;


### PR DESCRIPTION
  Tables created by the `postgres` role in the `public` schema no longer inherit INSERT/SELECT/UPDATE/DELETE for anon/authenticated/service_role under current Supabase CLI default privileges, so the Postgrest tests failed with "permission denied for table channels" (42501). Grant the privileges explicitly in the migration.