### PR TITLE
fix: correct csproj filename typo in release-please config

### DIFF
--- a/Supabase.sln
+++ b/Supabase.sln
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		CHANGELOG.md = CHANGELOG.md
 		docker-compose.yml = docker-compose.yml
 		README.md = README.md
+		release-please-config.json = release-please-config.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Supabase", "Supabase\Supabase.csproj", "{FAE80407-C121-47A3-9304-D39FA828E9F1}"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,7 @@
       "prerelease": false,
       "release-type": "simple",
       "extra-files": [
-        "Supabase/Supbase.csproj"
+        "Supabase/Supabase.csproj"
       ]
     }
   },


### PR DESCRIPTION
## Summary

A typo in `release-please-config.json` caused the version bump step to silently
target a non-existent file (`Supbase.csproj` instead of `Supabase.csproj`).

As a result, when v1.1.2 was released, the manifest and changelog were updated
correctly but `Supabase.csproj` was never patched — so no 1.1.2 package was
ever published to NuGet. The GitHub release and the published package have been
out of sync since then.

## What this changes

Corrects the filename in `extra-files` so subsequent releases patch the real
`.csproj`. The 1.1.2 gap is accepted; the next release (1.2.0, given pending
`feat:` commits) will be the first to tag and publish in lockstep.

## What this does not change

Nothing in the publish workflow, the manifest, or the `.csproj` itself. This is
a one-line config fix.