### PR TITLE
chore: update sdk-compliance.yaml for renamed capability matrix IDs

### DIFF
--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -40,7 +40,7 @@ features:
     symbols:
       - Client.VerifyOTP
       - Client.VerifyTokenHash
-  auth.sign_in.reset_password:
+  auth.sign_in.send_password_reset_email:
     status: implemented
     symbols:
       - Client.ResetPasswordForEmail
@@ -452,7 +452,7 @@ features:
     status: implemented
     symbols:
       - RealtimeChannel.Unsubscribe
-  realtime.channel.send:
+  realtime.channel.broadcast:
     status: implemented
     symbols:
       - RealtimeChannel.Send


### PR DESCRIPTION
## Summary
[supabase/sdk#74](https://github.com/supabase/sdk/pull/74) renames/splits several feature IDs in the canonical capability matrix. This repo's compliance file only declares two of the affected IDs:

- `auth.sign_in.reset_password` → `auth.sign_in.send_password_reset_email`
- `realtime.channel.send` → `realtime.channel.broadcast`

The `storage.file_buckets.list_files_paginated` merge and the two `storage.analytics.iceberg_*` splits from that PR aren't declared in this file at all, so there's nothing to update for those here.

Context: [SDK-1439](https://linear.app/supabase/issue/SDK-1439)

## Test plan
- [x] Validated against the updated registry with `npm run validate-compliance` from `supabase/sdk` (branch with #74's changes): `OK — compliance file is valid.`