### PR TITLE
chore: introduce central package management and pin the SDK

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,36 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <!--
+    Central Package Management: every package version for the whole solution lives here.
+    Individual projects reference packages with <PackageReference Include="..." /> (no Version).
+    Divergences resolved during consolidation:
+      - MSTest.TestAdapter/TestFramework unified to 4.3.3 (was 4.3.2 in five test projects).
+      - WireMock.Net unified to 2.13.0 (was 2.12.0 in three test projects).
+      - System.IdentityModel.Tokens.Jwt kept at 7.5.1 (Gotrue production) here; Functions.Tests
+        pins 8.19.2 locally via VersionOverride so production is not bumped to a new major.
+  -->
+  <ItemGroup>
+    <!-- Production dependencies -->
+    <PackageVersion Include="BirdMessenger" Version="4.0.0" />
+    <PackageVersion Include="MimeMapping" Version="4.0.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
+    <PackageVersion Include="Websocket.Client" Version="5.5.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+
+    <!-- Test dependencies -->
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageVersion Include="FluentAssertions" Version="[7.2.2]" />
+    <PackageVersion Include="NSubstitute" Version="[6.0.0]" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="WireMock.Net" Version="2.13.0" />
+    <PackageVersion Include="Npgsql" Version="[8.0.6]" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.2" />
+  </ItemGroup>
+</Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.300",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}

--- a/packages/Core/Core.Tests/Core.Tests.csproj
+++ b/packages/Core/Core.Tests/Core.Tests.csproj
@@ -14,15 +14,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-    <PackageReference Include="NSubstitute" Version="[6.0.0]" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>
 
   <ItemGroup>

--- a/packages/Core/Core/Core.csproj
+++ b/packages/Core/Core/Core.csproj
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/packages/Functions/Functions.Tests/Functions.Tests.csproj
+++ b/packages/Functions/Functions.Tests/Functions.Tests.csproj
@@ -12,18 +12,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-    <PackageReference Include="NSubstitute" Version="[6.0.0]" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.2" />
-    <PackageReference Include="WireMock.Net" Version="2.12.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" VersionOverride="8.19.2" />
+    <PackageReference Include="WireMock.Net" />
   </ItemGroup>
 
   <ItemGroup>

--- a/packages/Functions/Functions/Functions.csproj
+++ b/packages/Functions/Functions/Functions.csproj
@@ -40,8 +40,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/packages/Gotrue/Gotrue.Tests/Gotrue.Tests.csproj
+++ b/packages/Gotrue/Gotrue.Tests/Gotrue.Tests.csproj
@@ -12,17 +12,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1"/>
-    <PackageReference Include="MSTest.TestAdapter" Version="4.3.2"/>
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.2"/>
-    <PackageReference Include="NSubstitute" Version="[6.0.0]"/>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
-    <PackageReference Include="WireMock.Net" Version="2.12.0"/>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="MSTest.TestAdapter"/>
+    <PackageReference Include="MSTest.TestFramework"/>
+    <PackageReference Include="NSubstitute"/>
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="WireMock.Net"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/packages/Gotrue/Gotrue/Gotrue.csproj
+++ b/packages/Gotrue/Gotrue/Gotrue.csproj
@@ -54,9 +54,9 @@
         <LangVersion>8.0</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1"/>
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
+        <PackageReference Include="Newtonsoft.Json" />
+        <PackageReference Include="System.Diagnostics.DiagnosticSource"/>
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\Core\Core\Core.csproj" />

--- a/packages/Postgrest/Postgrest.Tests/Postgrest.Tests.csproj
+++ b/packages/Postgrest/Postgrest.Tests/Postgrest.Tests.csproj
@@ -13,17 +13,17 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
-		<PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="MSTest.TestAdapter" />
+		<PackageReference Include="MSTest.TestFramework" />
+		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-		<PackageReference Include="NSubstitute" Version="[6.0.0]" />
-		<PackageReference Include="Npgsql" Version="[8.0.6]" />
-		<PackageReference Include="WireMock.Net" Version="2.12.0" />
+		<PackageReference Include="FluentAssertions" />
+		<PackageReference Include="NSubstitute" />
+		<PackageReference Include="Npgsql" />
+		<PackageReference Include="WireMock.Net" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/packages/Postgrest/Postgrest/Postgrest.csproj
+++ b/packages/Postgrest/Postgrest/Postgrest.csproj
@@ -44,9 +44,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />
-        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+        <PackageReference Include="Newtonsoft.Json" />
     </ItemGroup>
 
     <ItemGroup>

--- a/packages/Realtime/Realtime.Tests/Realtime.Tests.csproj
+++ b/packages/Realtime/Realtime.Tests/Realtime.Tests.csproj
@@ -13,14 +13,14 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.3.2" />
-		<PackageReference Include="MSTest.TestFramework" Version="4.3.2" />
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="MSTest.TestAdapter" />
+		<PackageReference Include="MSTest.TestFramework" />
+		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
+		<PackageReference Include="FluentAssertions" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/packages/Realtime/Realtime/Realtime.csproj
+++ b/packages/Realtime/Realtime/Realtime.csproj
@@ -44,7 +44,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Newtonsoft.Json" />
     </ItemGroup>
 
     <ItemGroup>
@@ -53,11 +53,11 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="Websocket.Client" Version="5.5.0" />
+        <PackageReference Include="Websocket.Client" />
     </ItemGroup>
     
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-        <PackageReference Include="Websocket.Client" Version="5.5.0" />
+        <PackageReference Include="Websocket.Client" />
     </ItemGroup>
 
     <ItemGroup>

--- a/packages/Storage/Storage.Tests/Storage.Tests.csproj
+++ b/packages/Storage/Storage.Tests/Storage.Tests.csproj
@@ -13,16 +13,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-        <PackageReference Include="NSubstitute" Version="[6.0.0]" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-        <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
-        <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
-        <PackageReference Include="coverlet.collector" Version="10.0.1">
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="MSTest.TestAdapter" />
+        <PackageReference Include="MSTest.TestFramework" />
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="WireMock.Net" Version="2.13.0" />
+        <PackageReference Include="WireMock.Net" />
     </ItemGroup>
 
     <ItemGroup>

--- a/packages/Storage/Storage/Storage.csproj
+++ b/packages/Storage/Storage/Storage.csproj
@@ -40,10 +40,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BirdMessenger" Version="4.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-        <PackageReference Include="MimeMapping" Version="4.0.0" />
-        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+        <PackageReference Include="BirdMessenger" />
+        <PackageReference Include="Newtonsoft.Json" />
+        <PackageReference Include="MimeMapping" />
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" />
     </ItemGroup>
 
     <ItemGroup>

--- a/packages/Supabase/Supabase.Tests/Supabase.Tests.csproj
+++ b/packages/Supabase/Supabase.Tests/Supabase.Tests.csproj
@@ -14,12 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="[7.2.2]" />
-    <PackageReference Include="NSubstitute" Version="[6.0.0]" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
-    <PackageReference Include="coverlet.collector" Version="10.0.1"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
   </ItemGroup>

--- a/packages/Supabase/Supabase/Supabase.csproj
+++ b/packages/Supabase/Supabase/Supabase.csproj
@@ -42,8 +42,8 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+        <PackageReference Include="Newtonsoft.Json" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Monorepo scaffolding — Central Package Management + SDK pin

Introduces the shared build scaffolding deferred since PR 1, now that all packages are in the repo and their version divergences can be reconciled deliberately.

### What changed
- **`Directory.Packages.props`** with `ManagePackageVersionsCentrally=true` — every third-party version lives in one place. Inline `Version` stripped from all `PackageReference`s across the 14 package/test projects.
- **`global.json`** pins the SDK to `10.0.300` (`rollForward: latestMinor`) — the repo already requires .NET 10 (Storage.Tests targets `net10.0`).

### Version divergences resolved
- **MSTest.TestAdapter/TestFramework** → `4.3.3` (five test projects were on `4.3.2`).
- **WireMock.Net** → `2.13.0` (three were on `2.12.0`).
- **System.IdentityModel.Tokens.Jwt** → kept at `7.5.1` centrally (Gotrue **production**); only `Functions.Tests` keeps `8.19.2` via `VersionOverride`, so **no production dependency is bumped to a new major**. Verified resolved: Gotrue → 7.5.1, Functions.Tests → 8.19.2.
- Exact pins preserved: `[7.2.2]` FluentAssertions, `[6.0.0]` NSubstitute, `[8.0.6]` Npgsql.

### Verification
- `dotnet build Supabase.sln` under CPM → **0 errors** (CPM fails the build if any package lacks a central version, so this also proves completeness).
- **All seven suites green** (bumps didn't regress anything): Core 59, Functions 44, Gotrue 137, Postgrest 182, Realtime 113, Storage 156, umbrella 36.

### Deferred (future)
- `Directory.Build.props` for genuinely shared props (common metadata / repo URLs still pointing at the old sub-repos) — left out here since setting build-affecting defaults deserves its own deliberate pass. Also: docker-compose tidy, unified CI/release, and the GitHub/release-side tasks (v1-maintenance, issue migration, archiving).