### PR TITLE
chore: centralize shared package metadata in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,17 @@
+<Project>
+  <!--
+    Shared package metadata for every Supabase.* package in the monorepo. Now that all
+    packages live in one repository, the repository URL, licence, authors and copyright
+    are uniform, so they live here instead of being duplicated (and drifting) across each
+    csproj. Package-specific metadata (PackageId, Title, Description, tags, version, icon,
+    readme, and PackageProjectUrl which deep-links to each package's folder) stays in the
+    individual projects.
+  -->
+  <PropertyGroup>
+    <Authors>Supabase</Authors>
+    <Copyright>MIT</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/supabase-community/supabase-csharp</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+</Project>

--- a/packages/Core/Core/Core.csproj
+++ b/packages/Core/Core/Core.csproj
@@ -3,7 +3,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<PackOnBuild>true</PackOnBuild>
 		<PackageId>Supabase.Core</PackageId>
-		<Copyright>MIT</Copyright>
+		<PackageProjectUrl>https://github.com/supabase-community/supabase-csharp/tree/master/packages/Core</PackageProjectUrl>
 		<NeutralLanguage>en</NeutralLanguage>
 		<Summary>Shared core for supabase-csharp</Summary>
 		<Title>Supabase Core</Title>
@@ -14,11 +14,7 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageIconUrl>https://avatars.githubusercontent.com/u/54469796?s=200&amp;v=4</PackageIconUrl>
-		<PackageLicense>https://github.com/supabase-community/core-csharp/blob/master/LICENSE</PackageLicense>
-		<PackageProjectUrl>https://github.com/supabase-community/core-csharp</PackageProjectUrl>
 		<PackageTags>supabase, core</PackageTags>
-		<RepositoryUrl>https://github.com/supabase-community/core-csharp</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
 		<!-- x-release-please-start-version -->
 		<PackageVersion>1.2.0</PackageVersion>
 		<ReleaseVersion>1.2.0</ReleaseVersion>

--- a/packages/Functions/Functions/Functions.csproj
+++ b/packages/Functions/Functions/Functions.csproj
@@ -3,18 +3,15 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<PackOnBuild>true</PackOnBuild>
 		<PackageId>Supabase.Functions</PackageId>
+		<PackageProjectUrl>https://github.com/supabase-community/supabase-csharp/tree/master/packages/Functions</PackageProjectUrl>
 		<RootNamespace>Supabase.Functions</RootNamespace>
 		<AssemblyName>Supabase.Functions</AssemblyName>
-		<Authors>Joseph Schultz &lt;joseph@acupofjose.com&gt;</Authors>
-		<Copyright>MIT</Copyright>
 		<NeutralLanguage>en</NeutralLanguage>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Owners>Joseph Schultz &lt;joseph@acupofjose.com&gt;</Owners>
 		<Summary>A C# client for Supabase Functions</Summary>
 		<Title>Function</Title>
 		<Description>A C# client for Supabase Functions</Description>
 		<PackageIconUrl>https://avatars.githubusercontent.com/u/54469796?s=200&amp;v=4</PackageIconUrl>
-		<PackageProjectUrl>https://github.com/supabase-community/functions-csharp</PackageProjectUrl>
 		<PackageTags>supabase, functions</PackageTags>
     <!-- x-release-please-start-version -->
 		<PackageVersion>2.2.0</PackageVersion>
@@ -23,7 +20,6 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<RepositoryUrl>https://github.com/supabase-community/functions-csharp</RepositoryUrl>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/packages/Gotrue/Gotrue/Gotrue.csproj
+++ b/packages/Gotrue/Gotrue/Gotrue.csproj
@@ -4,28 +4,23 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <PackOnBuild>true</PackOnBuild>
         <PackageId>Supabase.Gotrue</PackageId>
+        <PackageProjectUrl>https://github.com/supabase-community/supabase-csharp/tree/master/packages/Gotrue</PackageProjectUrl>
         <RootNamespace>Supabase.Gotrue</RootNamespace>
         <AssemblyName>Supabase.Gotrue</AssemblyName>
-        <Authors>Joseph Schultz &lt;joseph@acupofjose.com&gt;</Authors>
-        <Copyright>MIT</Copyright>
         <NeutralLanguage>en</NeutralLanguage>
         <Owners>Joseph Schultz &lt;joseph@acupofjose.com&gt;</Owners>
         <Summary>A C# client for gotrue</Summary>
         <Title>Gotrue</Title>
         <Description>A C# client for gotrue</Description>
         <PackageIconUrl>https://avatars.githubusercontent.com/u/54469796?s=200&amp;v=4</PackageIconUrl>
-        <PackageProjectUrl>https://github.com/supabase-community/gotrue-csharp</PackageProjectUrl>
         <PackageTags>supabase, gotrue</PackageTags>
         <!-- x-release-please-start-version -->
         <PackageVersion>6.3.0</PackageVersion>
         <ReleaseVersion>6.3.0</ReleaseVersion>
         <!-- x-release-please-end -->
-        <RepositoryUrl>https://github.com/supabase-community/gotrue-csharp</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
         <PackageIcon>icon.png</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     </PropertyGroup>
     <PropertyGroup>

--- a/packages/Postgrest/Postgrest/Postgrest.csproj
+++ b/packages/Postgrest/Postgrest/Postgrest.csproj
@@ -7,15 +7,12 @@
         <Title>Supabase.Postgrest</Title>
         <AssemblyName>Supabase.Postgrest</AssemblyName>
         <PackageId>Supabase.Postgrest</PackageId>
+        <PackageProjectUrl>https://github.com/supabase-community/supabase-csharp/tree/master/packages/Postgrest</PackageProjectUrl>
         <RootNamespace>Supabase.Postgrest</RootNamespace>
-        <Authors>Joseph Schultz &lt;joseph@acupofjose.com&gt;</Authors>
         <PackOnBuild>true</PackOnBuild>
-        <Copyright>MIT</Copyright>
         <NeutralLanguage>en-US</NeutralLanguage>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Owners>Joseph Schultz &lt;joseph@acupofjose.com&gt;</Owners>
-        <PackageProjectUrl>https://github.com/supabase-community/postgrest-csharp</PackageProjectUrl>
         <Summary>Library to interact with postgREST servers</Summary>
         <Description>Postgrest-csharp is written primarily as a helper library for supabase/supabase-csharp, however, it should be easy enough to use outside of the supabase ecosystem.
             The bulk of this library is a translation and c-sharp-ification of the supabase/postgrest-js library.
@@ -29,8 +26,6 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <RepositoryUrl>https://github.com/supabase-community/postgrest-csharp</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/packages/Realtime/Realtime/Realtime.csproj
+++ b/packages/Realtime/Realtime/Realtime.csproj
@@ -3,17 +3,14 @@
         <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <Title>Supabase.Realtime</Title>
         <PackageId>Supabase.Realtime</PackageId>
+        <PackageProjectUrl>https://github.com/supabase-community/supabase-csharp/tree/master/packages/Realtime</PackageProjectUrl>
         <RootNamespace>Supabase.Realtime</RootNamespace>
         <AssemblyName>Supabase.Realtime</AssemblyName>
-        <Authors>Joseph Schultz &lt;joseph@acupofjose.com&gt;</Authors>
         <Description>Realtime-csharp is written as a client library for supabase/realtime.</Description>
         <PackOnBuild>true</PackOnBuild>
-        <Copyright>MIT</Copyright>
         <NeutralLanguage>en</NeutralLanguage>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Owners>Joseph Schultz &lt;joseph@acupofjose.com&gt;</Owners>
-        <PackageProjectUrl>https://github.com/supabase/realtime-csharp</PackageProjectUrl>
         <Summary>Realtime-csharp is written as a  client library for supabase/realtime.</Summary>
         <PackageTags>supabase, realtime, phoenix</PackageTags>
         <!-- x-release-please-start-version -->
@@ -23,7 +20,6 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <RepositoryUrl>https://github.com/supabase/realtime-csharp</RepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/packages/Storage/Storage/Storage.csproj
+++ b/packages/Storage/Storage/Storage.csproj
@@ -3,15 +3,12 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <PackOnBuild>true</PackOnBuild>
         <PackageId>Supabase.Storage</PackageId>
+        <PackageProjectUrl>https://github.com/supabase-community/supabase-csharp/tree/master/packages/Storage</PackageProjectUrl>
         <RootNamespace>Supabase.Storage</RootNamespace>
         <AssemblyName>Supabase.Storage</AssemblyName>
-        <Authors>Joseph Schultz &lt;joseph@acupofjose.com&gt;</Authors>
         <Description>A C# implementation of the Supabase Storage client</Description>
-        <Copyright>MIT</Copyright>
         <NeutralLanguage>en-US</NeutralLanguage>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Owners>Joseph Schultz &lt;joseph@acupofjose.com&gt;</Owners>
-        <PackageProjectUrl>https://github.com/supabase-community/storage-csharp</PackageProjectUrl>
         <Summary>A C# implementation of the Supabase Storage client</Summary>
         <Title>Supabase Storage</Title>
         <PackageIconUrl>https://avatars.githubusercontent.com/u/54469796?s=200&amp;v=4</PackageIconUrl>
@@ -20,8 +17,6 @@
         <ReleaseVersion>2.7.0</ReleaseVersion>
         <PackageVersion>2.7.0</PackageVersion>
         <!-- x-release-please-end -->
-        <RepositoryUrl>https://github.com/supabase-community/storage-csharp</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/packages/Supabase/Supabase/Supabase.csproj
+++ b/packages/Supabase/Supabase/Supabase.csproj
@@ -7,16 +7,13 @@
         <PackOnBuild>true</PackOnBuild>
         <Title>Supabase</Title>
         <PackageId>Supabase</PackageId>
+        <PackageProjectUrl>https://github.com/supabase-community/supabase-csharp/tree/master/packages/Supabase</PackageProjectUrl>
         <RootNamespace>Supabase</RootNamespace>
         <AssemblyName>Supabase</AssemblyName>
-        <Authors>Joseph Schultz &lt;joseph@acupofjose.com&gt;</Authors>
         <Description>A C# implementation of the Supabase client</Description>
-        <Copyright>MIT</Copyright>
         <NeutralLanguage>en</NeutralLanguage>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Owners>Joseph Schultz &lt;joseph@acupofjose.com&gt;</Owners>
-        <PackageProjectUrl>https://github.com/supabase-community/supabase-csharp</PackageProjectUrl>
         <Summary>A C# implementation of the Supabase client</Summary>
         <PackageTags>supabase</PackageTags>
         <!-- x-release-please-start-version -->
@@ -26,7 +23,6 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <RepositoryUrl>https://github.com/supabase-community/supabase-csharp</RepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
## Monorepo scaffolding — Directory.Build.props (item 1)

Adds `Directory.Build.props` for metadata that is now uniform across all packages, fixes the stale package URLs, and updates authorship for the official Supabase-supported era.

### What changed
- New root `Directory.Build.props` sets the uniform metadata: `Authors`, `Copyright`, `PackageLicenseExpression=MIT`, `RepositoryUrl` (→ the monorepo) and `RepositoryType=git`. Removed those from all seven production csprojs.
- **`Authors` → `Supabase`** — the SDK is now officially supported by Supabase rather than community-maintained by an individual. (Original authorship is preserved in git history.)
- **`PackageProjectUrl` stays per-package**, deep-linking to each package's folder (e.g. `…/tree/master/packages/Gotrue`) so its nuget.org page lands on the right README. `RepositoryUrl` stays uniform because SourceLink maps to the single monorepo.
- **Fixes stale metadata**: every leaf package's `RepositoryUrl`/`PackageProjectUrl` still pointed at its old standalone repo (Realtime at the wrong org). Also dropped Core's `<PackageLicense>` URL — an inert, non-standard property; Core now inherits `PackageLicenseExpression=MIT`, which it previously lacked entirely.

### Verification
- `dotnet build Supabase.sln` → **0 errors**.
- Resolved values confirmed, e.g. Gotrue → `Authors=Supabase`, `PackageProjectUrl=…/packages/Gotrue`; Realtime `RepositoryUrl` → the monorepo; Core `PackageLicenseExpression` → `MIT`.

Metadata-only; no compilation or behavior change.