### PR TITLE
ci: rework build-and-test for the monorepo

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,14 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Use the SDK pinned in global.json so CI matches local builds.
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
 
-      # The E2E tier runs against a local Supabase stack (migrations, edge functions,
-      # buckets and the realtime publication all come from supabase/).
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
@@ -39,12 +36,6 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
 
-      # -m:1 runs the test projects one at a time. `dotnet test` on a solution launches a
-      # VSTest process per project via MSBuild, and by default MSBuild runs them in parallel;
-      # since the E2E tier shares one stateful Supabase stack (Postgrest's fixture
-      # truncates/reseeds public between runs), parallel assemblies against the same database
-      # would be flaky. MSBuild -m:1 is the lever here -- a VSTest .runsettings MaxCpuCount
-      # does not help, as it only governs assemblies within a single VSTest process.
       - name: Test
         run: dotnet test Supabase.sln --configuration Release --no-build -m:1
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,39 +6,45 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
-      AWS_REGION: ${{ secrets.AWS_REGION }}
-
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
+      # Use the SDK pinned in global.json so CI matches local builds.
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.x
+          global-json-file: global.json
 
-      - uses: supabase/setup-cli@v1
+      # The E2E tier runs against a local Supabase stack (migrations, edge functions,
+      # buckets and the realtime publication all come from supabase/).
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
         with:
           version: latest
 
-      - name: Start supabase
+      - name: Start Supabase
         run: supabase start
-        
-      - name: Restore dependencies
+
+      - name: Restore
         run: dotnet restore
 
       - name: Build
         run: dotnet build --configuration Release --no-restore
 
-#      - name: Initialize Testing Stack
-#        run: docker compose up -d
-
+      # -m:1 runs the test projects one at a time. `dotnet test` on a solution launches a
+      # VSTest process per project via MSBuild, and by default MSBuild runs them in parallel;
+      # since the E2E tier shares one stateful Supabase stack (Postgrest's fixture
+      # truncates/reseeds public between runs), parallel assemblies against the same database
+      # would be flaky. MSBuild -m:1 is the lever here -- a VSTest .runsettings MaxCpuCount
+      # does not help, as it only governs assemblies within a single VSTest process.
       - name: Test
-        run: dotnet test --no-restore
+        run: dotnet test Supabase.sln --configuration Release --no-build -m:1
+


### PR DESCRIPTION
## Monorepo CI (item 3)

The monorepo had no working CI: the old `build-and-test.yml` pinned **.NET 8.x** (can't build `net10.0` / the `global.json` 10.x pin) and only built the umbrella. This replaces it with one job that builds and tests the whole repo.

### What changed
- **.NET from `global.json`** (`actions/setup-dotnet@v4` with `global-json-file`) — CI uses the same pinned SDK as local builds, so the SDK bumps in one place.
- **Local Supabase stack** (`supabase/setup-cli` + `supabase start`) for the E2E tier.
- **Restore → build Release (whole solution) → test.**
- **Tests run with MSBuild `-m:1`** so the projects execute one at a time.
- Dropped the commented-out `docker compose` step and unused AWS secrets; added `concurrency` to cancel superseded runs.

### Why `-m:1` and not a `for` loop / a VSTest setting
Verified all three locally (stack up, Release):
- **Default `dotnet test <solution>`** → the seven assemblies start **in parallel** (all "starting" lines batch together). Risky against one shared, stateful stack — Postgrest's `DatabaseFixture` truncates/reseeds `public` while e.g. the umbrella's channel test counts rows.
- **VSTest `.runsettings` `MaxCpuCount=1`** → **still parallel.** `dotnet test` on a solution launches a *separate VSTest process per project* via MSBuild, so a VSTest-internal setting (which governs assemblies within one process) doesn't apply across projects.
- **MSBuild `-m:1`** → **serial** (each assembly starts and finishes before the next) and green. This is the effective, idiomatic lever — no shell loop needed. Note this is a runner/MSBuild concern, not something MSTest exposes: MSTest (like xUnit collections) only controls parallelism *within* an assembly.

### Verification
- `dotnet build --configuration Release --no-restore` → 0 errors.
- `dotnet test Supabase.sln --configuration Release --no-build -m:1` → **all seven serial and green**: Core 59, Functions 44, Gotrue 137, Postgrest 182, Realtime 113, Storage 156, umbrella 36.

(The workflow itself gets its first real run when opened against `master`.)