### PR TITLE
build!: retarget packages to netstandard2.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,26 @@
     <RepositoryUrl>https://github.com/supabase-community/supabase-csharp</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!--
+      "latest" tracks the installed SDK's newest C# so packages are never stuck behind the
+      language, independent of the netstandard2.1 target. It is uniform here so it cannot
+      drift per package (it previously did: some projects pinned 8.0/9.0, others latest).
+      Using C# 9+ init-only setters or records on netstandard2.1 needs a local
+      System.Runtime.CompilerServices.IsExternalInit shim.
+    -->
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <!--
+    Target frameworks are uniform across the monorepo: shipped packages ship as
+    netstandard2.1, and test projects run on net10.0. Keyed off the project-name suffix
+    so a new package or test project inherits the right target with no per-project setting.
+  -->
+  <PropertyGroup Condition="!$(MSBuildProjectName.EndsWith('.Tests'))">
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!--

--- a/packages/Core/Core.Tests/Core.Tests.csproj
+++ b/packages/Core/Core.Tests/Core.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Core.Tests</AssemblyName>
     <RootNamespace>Core.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
@@ -10,7 +9,6 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/Core/Core/Core.csproj
+++ b/packages/Core/Core/Core.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
 		<PackOnBuild>true</PackOnBuild>
 		<PackageId>Supabase.Core</PackageId>
 		<PackageProjectUrl>https://github.com/supabase-community/supabase-csharp/tree/master/packages/Core</PackageProjectUrl>
@@ -24,7 +23,6 @@
 	
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
-		<LangVersion>default</LangVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 	</PropertyGroup>
 

--- a/packages/Functions/Functions.Tests/Functions.Tests.csproj
+++ b/packages/Functions/Functions.Tests/Functions.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Functions.Tests</AssemblyName>
     <RootNamespace>Functions.Tests</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/packages/Functions/Functions/Functions.csproj
+++ b/packages/Functions/Functions/Functions.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
 		<PackOnBuild>true</PackOnBuild>
 		<PackageId>Supabase.Functions</PackageId>
 		<PackageProjectUrl>https://github.com/supabase-community/supabase-csharp/tree/master/packages/Functions</PackageProjectUrl>
@@ -22,7 +21,6 @@
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Nullable>enable</Nullable>
-		<LangVersion>8.0</LangVersion>
 		<WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
 	</PropertyGroup>
 

--- a/packages/Gotrue/Gotrue.Tests/Gotrue.Tests.csproj
+++ b/packages/Gotrue/Gotrue.Tests/Gotrue.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Gotrue.Tests</AssemblyName>
     <RootNamespace>Gotrue.Tests</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/packages/Gotrue/Gotrue/Gotrue.csproj
+++ b/packages/Gotrue/Gotrue/Gotrue.csproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
         <PackOnBuild>true</PackOnBuild>
         <PackageId>Supabase.Gotrue</PackageId>
         <PackageProjectUrl>https://github.com/supabase-community/supabase-csharp/tree/master/packages/Gotrue</PackageProjectUrl>
@@ -27,7 +26,6 @@
     </PropertyGroup>
     <PropertyGroup>
         <Nullable>enable</Nullable>
-        <LangVersion>9.0</LangVersion>
         <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
     </PropertyGroup>
     <PropertyGroup>
@@ -39,12 +37,6 @@
         </VersionSuffix>
         <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
         <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <LangVersion>8.0</LangVersion>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" />

--- a/packages/Postgrest/Postgrest.Tests/Postgrest.Tests.csproj
+++ b/packages/Postgrest/Postgrest.Tests/Postgrest.Tests.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
 		<AssemblyName>Postgrest.Tests</AssemblyName>
 		<RootNamespace>Postgrest.Tests</RootNamespace>
 		<IsPackable>false</IsPackable>
 		<Nullable>enable</Nullable>
-		<LangVersion>latest</LangVersion>
 		<WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/packages/Postgrest/Postgrest/Postgrest.csproj
+++ b/packages/Postgrest/Postgrest/Postgrest.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <LangVersion>9.0</LangVersion>
         <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
         <Nullable>enable</Nullable>
         <Title>Supabase.Postgrest</Title>

--- a/packages/Realtime/Realtime.Tests/Realtime.Tests.csproj
+++ b/packages/Realtime/Realtime.Tests/Realtime.Tests.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<IsPackable>false</IsPackable>
-		<TargetFramework>net8.0</TargetFramework>
 		<AssemblyName>Realtime.Tests</AssemblyName>
 		<RootNamespace>Realtime.Tests</RootNamespace>
 		<Nullable>enable</Nullable>
-		<LangVersion>latest</LangVersion>
 		<WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/packages/Realtime/Realtime/Realtime.csproj
+++ b/packages/Realtime/Realtime/Realtime.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <Title>Supabase.Realtime</Title>
         <PackageId>Supabase.Realtime</PackageId>
         <PackageProjectUrl>https://github.com/supabase-community/supabase-csharp/tree/master/packages/Realtime</PackageProjectUrl>
@@ -23,7 +22,6 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Nullable>enable</Nullable>
-        <LangVersion>latest</LangVersion>
         <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
     </PropertyGroup>
 
@@ -47,11 +45,7 @@
         <ProjectReference Include="..\..\Postgrest\Postgrest\Postgrest.csproj" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="Websocket.Client" />
-    </ItemGroup>
-    
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <ItemGroup>
         <PackageReference Include="Websocket.Client" />
     </ItemGroup>
 

--- a/packages/Storage/Storage.Tests/Storage.Tests.csproj
+++ b/packages/Storage/Storage.Tests/Storage.Tests.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <AssemblyName>Storage.Tests</AssemblyName>
         <RootNamespace>Storage.Tests</RootNamespace>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
-        <LangVersion>default</LangVersion>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <AnalysisLevel>latest</AnalysisLevel>

--- a/packages/Storage/Storage/Storage.csproj
+++ b/packages/Storage/Storage/Storage.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
         <PackOnBuild>true</PackOnBuild>
         <PackageId>Supabase.Storage</PackageId>
         <PackageProjectUrl>https://github.com/supabase-community/supabase-csharp/tree/master/packages/Storage</PackageProjectUrl>
@@ -23,7 +22,6 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Nullable>enable</Nullable>
-        <LangVersion>latest</LangVersion>
         <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
     </PropertyGroup>
 

--- a/packages/Supabase/Supabase.Tests/Supabase.Tests.csproj
+++ b/packages/Supabase/Supabase.Tests/Supabase.Tests.csproj
@@ -5,12 +5,12 @@
     <IsPackable>false</IsPackable>
     <ReleaseVersion>0.8.5</ReleaseVersion>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Supabase.Tests</AssemblyName>
     <RootNamespace>Supabase.Tests</RootNamespace>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest</AnalysisLevel>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/Supabase/Supabase/Supabase.csproj
+++ b/packages/Supabase/Supabase/Supabase.csproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <LangVersion>9.0</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
         <PackOnBuild>true</PackOnBuild>
@@ -25,7 +24,6 @@
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
    
     <PropertyGroup Condition=" '$(Version)' == '' ">


### PR DESCRIPTION
Unify every shipped package on netstandard2.1 (was netstandard2.0) and move test projects to net10.0 (was net8.0).

BREAKING CHANGE: packages now target netstandard2.1 instead of netstandard2.0. .NET Framework consumers (netstandard2.0 is its ceiling) and pre-netstandard2.1 runtimes (Mono <6.4, older Xamarin/Unity) can no longer reference these packages and must move to a netstandard2.1-capable target (.NET Core 3.0+/.NET 5+).